### PR TITLE
Stratified Tree estimations

### DIFF
--- a/R/SDForest.R
+++ b/R/SDForest.R
@@ -61,14 +61,12 @@
 #' This is a trade-off between memory and speed can be decreased if either
 #' the memory is not sufficient or the gpu is to small.
 #' @param leave_out_ind Indices of observations that should not be used for training.
-#' @param envs Vector of environments which can be used for stratified tree fitting.
-#' NOT SUPPORTED YET
-#' @param leave_envs_out_trees Number of trees that should be estimated while leaving
+#' @param envs Vector of environments of class \code{factor} 
+#' which can be used for stratified tree fitting.
+#' @param nTree_leave_out Number of trees that should be estimated while leaving
 #' one of the environments out. Results in number of environments times number of trees.
-#' NOT SUPPORTED YET
-#' @param envs_trees Number of trees that should be estimated for each environment.
+#' @param nTree_env Number of trees that should be estimated for each environment.
 #' Results in number of environments times number of trees.
-#' NOT SUPPORTED YET
 #' @param max_candidates Maximum number of split points that are 
 #' proposed at each node for each covariate.
 #' @return Object of class \code{SDForest} containing:
@@ -87,6 +85,17 @@
 #' \item{X}{Matrix of covariates.}
 #' \item{Y}{Vector of responses.}
 #' \item{Q}{Spectral transformation matrix.}
+#' If \code{envs} is provided the following are also returned:
+#' \item{envs}{Vector of environments.}
+#' \item{nTree_env}{Number of trees for each environment.}
+#' \item{ooEnv_ind}{List of indices of trees that did not contain the observation or the same environment in the training set
+#' for each observation.}
+#' \item{ooEnv_loss}{Out-of-bag loss using only trees that did not contain the observation or the same environment.}
+#' \item{ooEnv_SDloss}{Out-of-bag loss using the spectral transformation and only trees that did not contain the observation
+#' or the same environment.}
+#' \item{ooEnv_predictions}{Out-of-bag predictions using only trees that did not contain the observation or the same environment.}
+#' \item{nTree_leave_out}{If environments are left out, the environment for each tree, that was left out.}
+#' \item{nTree_env}{If environments are provided, the environment each tree is trained with.}
 #' @seealso \code{\link{get_Q}}, \code{\link{get_W}}, \code{\link{SDTree}}, 
 #' \code{\link{simulate_data_nonlinear}}, \code{\link{regPath}}, 
 #' \code{\link{stabilitySelection}}, \code{\link{prune}}, \code{\link{partDependence}}
@@ -140,7 +149,7 @@ SDForest <- function(formula = NULL, data = NULL, x = NULL, y = NULL, nTree = 10
                      Q_type = 'trim', trim_quantile = 0.5, q_hat = 0, Q = NULL, 
                      A = NULL, gamma = 7, max_size = NULL, gpu = FALSE, 
                      return_data = TRUE, mem_size = 1e+7, leave_out_ind = NULL, 
-                     envs = NULL, leave_envs_out_trees = NULL, envs_trees = NULL, 
+                     envs = NULL, nTree_leave_out = NULL, nTree_env = NULL, 
                      max_candidates = 100){
   if(gpu) ifelse(GPUmatrix::installTorch(), 
                  gpu_type <- 'torch', 
@@ -165,12 +174,13 @@ SDForest <- function(formula = NULL, data = NULL, x = NULL, y = NULL, nTree = 10
 
   if(!is.null(leave_out_ind) && any(leave_out_ind >= n, leave_out_ind < 1)) 
     stop('leave_out_ind must be smaller than n')
-  if(!is.null(envs) && length(envs) != n) 
-    stop('envs must have length n')
-  if(!is.null(envs) && !is.null(leave_envs_out_trees) && !is.null(envs_trees))
-    stop('leave_envs_out_trees and envs_trees cannot be used together')
-  if(!is.null(envs) && !(all(!is.null(leave_envs_out_trees), leave_envs_out_trees > 0) | all(!is.null(envs_trees), envs_trees > 0)))
-    stop('either leave_envs_out_trees or envs_trees must be provided larger than 0')
+  if(!is.null(envs) && any(length(envs) != n, !is.factor(envs)))
+    stop('envs must be a factor of length n')
+  if(!is.null(envs) && !is.null(nTree_leave_out) && !is.null(nTree_env))
+    stop('nTree_leave_out and nTree_env cannot be used together')
+  if(!is.null(envs) && !(all(!is.null(nTree_leave_out), nTree_leave_out > 0) | 
+                         all(!is.null(nTree_env), nTree_env > 0)))
+    stop('either nTree_leave_out or nTree_env must be provided larger than 0')
 
   if(!is.null(A)){
     if(is.null(gamma)) stop('gamma must be provided if A is provided')
@@ -199,17 +209,6 @@ SDForest <- function(formula = NULL, data = NULL, x = NULL, y = NULL, nTree = 10
   }
 
   # bootstrap samples
-  #TODO: add support for stratified fitting
-
-# @param envs Vector of environments which can be used for stratified tree fitting.
-# NOT SUPPORTED YET
-# @param leave_envs_out_trees Number of trees that should be estimated while leaving
-# one of the environments out. Results in number of environments times number of trees.
-# NOT SUPPORTED YET
-# @param envs_trees Number of trees that should be estimated for each environment.
-# Results in number of environments times number of trees.
-# NOT SUPPORTED YET
-
   all_ind <- 1:n
   if(!is.null(leave_out_ind)){
     all_ind <- all_ind[-leave_out_ind]
@@ -221,11 +220,40 @@ SDForest <- function(formula = NULL, data = NULL, x = NULL, y = NULL, nTree = 10
   if(is.null(envs)){
     ind <- lapply(1:nTree, function(x)
       sample(all_ind, min(length(all_ind), max_size), replace = TRUE))
-  }else{
-    ind <- lapply(1:nTree, function(x)
-      sample(all_ind, min(length(all_ind), max_size), replace = TRUE))   
+  }else{# stratified bootstrapping
+    nEnv <- length(levels(envs))
+    if(nEnv == 1) stop('only one environment is provided')
+    nTree_env <- if(!is.null(nTree_leave_out)) 
+      nTree_leave_out else nTree_env
+    if(length(nTree_env) > 1){
+      if(any(length(nTree_env) != nEnv, 
+             !setequal(names(nTree_env), levels(envs)))){
+        stop('if nTree_env is a vector, it must have the same length as 
+             levels(envs) and the names must be the levels of envs')
+      }
+    }else {
+      nTree_env <- rep(nTree_env, nEnv)
+      names(nTree_env) <- levels(envs)
+    }
+    tree_env <- rep(names(nTree_env), nTree_env)
+
+    nTree <- sum(nTree_env)
+    print(paste0("Fitting stratified trees resultin in ", nTree, " trees."))
+
+    ind <- lapply(names(nTree_env), function(env_l) {
+      lapply(1:nTree_env[env_l], function(x) {
+      if(!is.null(nTree_leave_out)){
+        # not use leave out environment for training
+        all_ind_env <- all_ind[envs != env_l]
+      }else{
+        # use only specific environment for training
+        all_ind_env <- all_ind[envs == env_l]
+      }
+      sample(all_ind_env, min(length(all_ind_env), max_size), replace = TRUE)
+      })})
+      ind <- do.call(c, ind)
   }
-  
+
   if(mc.cores > 1){
     if(locatexec::is_unix()){
       print('mclapply')
@@ -276,8 +304,39 @@ SDForest <- function(formula = NULL, data = NULL, x = NULL, y = NULL, nTree = 10
     return(mean(predictions))
   })
 
-  oob_SDloss <- loss(Q %*% Y, Q %*% oob_predictions)
+  Y_tilde <- Q %*% Y
+  oob_SDloss <- loss(Y_tilde, Q %*% oob_predictions)
   oob_loss <- loss(Y, oob_predictions)
+
+
+  if(!is.null(envs)){
+    # oob predictions only with model not trained on the same environment
+    if(!is.null(nTree_leave_out)){
+      ooEnv_ind <- lapply(1:n, function(i){
+        idx <- oob_ind[[i]]
+        idx[tree_env[idx] == envs[i]]
+      })
+    }else{
+      ooEnv_ind <- lapply(1:n, function(i){
+        idx <- oob_ind[[i]]
+        idx[tree_env[idx] != envs[i]]
+      })
+    }
+
+    ooEnv_predictions <- sapply(1:n, function(i){
+      if(length(ooEnv_ind[[i]]) == 0){
+        return(NA)
+      }
+      xi <- X[i, ]
+      predictions <- sapply(ooEnv_ind[[i]], function(model){
+        predict_outsample(res[[model]]$tree, xi)
+      })
+      return(mean(predictions))
+    })
+
+    ooEnv_SDloss <- loss(Y_tilde, Q %*% ooEnv_predictions)
+    ooEnv_loss <- loss(Y, ooEnv_predictions)
+  }
 
   # predict with all trees
   pred <- do.call(cbind, lapply(res, function(x){predict_outsample(x$tree, X)}))
@@ -307,7 +366,21 @@ SDForest <- function(formula = NULL, data = NULL, x = NULL, y = NULL, nTree = 10
     output$Y <- as.matrix(Y)
     output$Q <- as.matrix(Q)
   }
+
+  if(!is.null(envs)){
+    if(!is.null(nTree_leave_out)){
+      output$nTree_leave_out <- tree_env
+    }else{
+      output$nTree_env <- tree_env
+    }
+    output$tree_env <- nTree_env
+    output$envs <- envs
+    output$ooEnv_ind <- ooEnv_ind
+    output$ooEnv_loss <- ooEnv_loss
+    output$ooEnv_SDloss <- ooEnv_SDloss
+    output$ooEnv_predictions <- ooEnv_predictions
+  }
+
   class(output) <- 'SDForest'
-  
   output
 }

--- a/inst/tinytest/test-strat.R
+++ b/inst/tinytest/test-strat.R
@@ -1,0 +1,26 @@
+set.seed(24)
+
+n <- 50
+x <- rnorm(n)
+y <- x**2
+a <- factor(sample(letters[1:3], n, replace = TRUE))
+
+expect_error(SDForest(x = x, y = y, envs = a, Q_type = 'no_deconfounding'))
+SDForest(x = x, y = y, nTree_leave_out = 2, envs = a, Q_type = 'no_deconfounding')
+SDForest(x = x, y = y, nTree_env = 2, envs = a, Q_type = 'no_deconfounding')
+ntrees <- c(3, 1, 5)
+
+# need names
+expect_error(SDForest(x = x, y = y, nTree_leave_out = ntrees, envs = a, Q_type = 'no_deconfounding'))
+expect_error(SDForest(x = x, y = y, nTree_env = ntrees, envs = a, Q_type = 'no_deconfounding'))
+
+names(ntrees) <- levels(a)
+fit <- SDForest(x = x, y = y, nTree_leave_out = ntrees, envs = a, Q_type = 'no_deconfounding')
+expect_null(fit$nTree_env)
+expect_equal(fit$tree_env, ntrees)
+expect_equal(length(fit$forest), sum(ntrees))
+
+fit <- SDForest(x = x, y = y, nTree_env = ntrees, envs = a, Q_type = 'no_deconfounding')
+expect_null(fit$nTree_leave_out)
+expect_equal(fit$tree_env, ntrees)
+expect_equal(length(fit$forest), sum(ntrees))

--- a/man/SDForest.Rd
+++ b/man/SDForest.Rd
@@ -26,8 +26,8 @@ SDForest(
   mem_size = 1e+07,
   leave_out_ind = NULL,
   envs = NULL,
-  leave_envs_out_trees = NULL,
-  envs_trees = NULL,
+  nTree_leave_out = NULL,
+  nTree_env = NULL,
   max_candidates = 100
 )
 }
@@ -95,16 +95,14 @@ the memory is not sufficient or the gpu is to small.}
 
 \item{leave_out_ind}{Indices of observations that should not be used for training.}
 
-\item{envs}{Vector of environments which can be used for stratified tree fitting.
-NOT SUPPORTED YET}
+\item{envs}{Vector of environments of class \code{factor} 
+which can be used for stratified tree fitting.}
 
-\item{leave_envs_out_trees}{Number of trees that should be estimated while leaving
-one of the environments out. Results in number of environments times number of trees.
-NOT SUPPORTED YET}
+\item{nTree_leave_out}{Number of trees that should be estimated while leaving
+one of the environments out. Results in number of environments times number of trees.}
 
-\item{envs_trees}{Number of trees that should be estimated for each environment.
-Results in number of environments times number of trees.
-NOT SUPPORTED YET}
+\item{nTree_env}{Number of trees that should be estimated for each environment.
+Results in number of environments times number of trees.}
 
 \item{max_candidates}{Maximum number of split points that are 
 proposed at each node for each covariate.}
@@ -126,6 +124,17 @@ If \code{return_data} is \code{TRUE} the following are also returned:
 \item{X}{Matrix of covariates.}
 \item{Y}{Vector of responses.}
 \item{Q}{Spectral transformation matrix.}
+If \code{envs} is provided the following are also returned:
+\item{envs}{Vector of environments.}
+\item{nTree_env}{Number of trees for each environment.}
+\item{ooEnv_ind}{List of indices of trees that did not contain the observation or the same environment in the training set
+for each observation.}
+\item{ooEnv_loss}{Out-of-bag loss using only trees that did not contain the observation or the same environment.}
+\item{ooEnv_SDloss}{Out-of-bag loss using the spectral transformation and only trees that did not contain the observation
+or the same environment.}
+\item{ooEnv_predictions}{Out-of-bag predictions using only trees that did not contain the observation or the same environment.}
+\item{nTree_leave_out}{If environments are left out, the environment for each tree, that was left out.}
+\item{nTree_env}{If environments are provided, the environment each tree is trained with.}
 }
 \description{
 Estimate regression Random Forest using spectral deconfounding.


### PR DESCRIPTION
A feature to estimate trees in SDForest controlled using a categorical environment variable. Either estimate trees using specific environments or leave specific environments out of training. It can be used for distribution shift / distributional robustness, etc.